### PR TITLE
SAV-3176: Document borescope analysis eligibility fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,30 @@ curl -X POST https://apps.savvyaviation.com/get-aircraft/ --form "token=[YOUR_TO
 
 It returns a "application/json" response, as an array of objects. The array may be empty.
 
-Each object contains the registration and database id of the aircraft in question as show in the example below:
+Each object contains the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | integer | Database id of the aircraft. |
+| `registration_no` | string | Aircraft registration (tail number). |
+| `eligibleForBorescopeAnalysis` | boolean | Whether this aircraft is currently covered by a subscription plan that includes borescope image analysis (Analysis, QA, MX, or Prebuy). Clients should use this flag to decide whether to surface the "Request Analysis" action and to prompt the user to upgrade when it is `false`. Recomputed on every call, so the value reflects the aircraft's eligibility at request time. |
+| `serviceUpgradeUrl` | string (URI) | Deep link to the SavvyAviation web app plan page for this specific aircraft, where the owner can upgrade to a subscription that includes borescope analysis. Present **if and only if** `eligibleForBorescopeAnalysis` is `false`; when eligibility is `true`, the field is omitted entirely (not returned as `null`). |
+
+Example response when the aircraft is eligible for borescope analysis:
 
 ```json
-[{ "registration_no": "N123", "id": 15678 }]
+[{ "registration_no": "N123", "id": 15678, "eligibleForBorescopeAnalysis": true }]
+```
+
+Example response when the aircraft is not eligible:
+
+```json
+[{
+  "registration_no": "N123",
+  "id": 15678,
+  "eligibleForBorescopeAnalysis": false,
+  "serviceUpgradeUrl": "https://apps.savvyaviation.com/account/plan/15678"
+}]
 ```
 
 ## File Upload API

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -43,13 +43,22 @@ paths:
                       description: Aircraft registration number
                     eligibleForBorescopeAnalysis:
                       type: boolean
-                      description: Whether the aircraft owner's current subscription plan includes borescope image analysis
+                      description: >
+                        Whether this aircraft is currently covered by a subscription plan
+                        that includes borescope image analysis (Analysis, QA, MX, or Prebuy).
+                        Clients should use this flag to decide whether to surface the
+                        "Request Analysis" action in their UI and to prompt the user to
+                        upgrade when it is `false`. Recomputed on every call, so the value
+                        reflects the aircraft's eligibility at request time.
                     serviceUpgradeUrl:
                       type: string
                       format: uri
                       description: >
-                        URL where the user can upgrade their subscription to enable borescope analysis.
-                        Only present when eligibleForBorescopeAnalysis is false.
+                        Deep link to the SavvyAviation web app plan page for this specific
+                        aircraft, where the owner can upgrade to a subscription that
+                        includes borescope analysis. Present if and only if
+                        `eligibleForBorescopeAnalysis` is `false`; when eligibility is
+                        `true`, the field is omitted entirely (not returned as `null`).
                       example: https://apps.savvyaviation.com/account/plan/1234
               examples:
                 eligible:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,6 +33,7 @@ paths:
                 type: array
                 items:
                   type: object
+                  required: [id, registration_no, eligibleForBorescopeAnalysis]
                   properties:
                     id:
                       type: integer
@@ -40,6 +41,30 @@ paths:
                     registration_no:
                       type: string
                       description: Aircraft registration number
+                    eligibleForBorescopeAnalysis:
+                      type: boolean
+                      description: Whether the aircraft owner's current subscription plan includes borescope image analysis
+                    serviceUpgradeUrl:
+                      type: string
+                      format: uri
+                      description: >
+                        URL where the user can upgrade their subscription to enable borescope analysis.
+                        Only present when eligibleForBorescopeAnalysis is false.
+                      example: https://apps.savvyaviation.com/account/plan/1234
+              examples:
+                eligible:
+                  summary: Aircraft eligible for borescope analysis
+                  value:
+                    - id: 1234
+                      registration_no: N12345
+                      eligibleForBorescopeAnalysis: true
+                ineligible:
+                  summary: Aircraft not eligible (includes upgrade URL)
+                  value:
+                    - id: 5678
+                      registration_no: N67890
+                      eligibleForBorescopeAnalysis: false
+                      serviceUpgradeUrl: https://apps.savvyaviation.com/account/plan/5678
         '401':
           $ref: '#/components/responses/Unauthorized'
 


### PR DESCRIPTION
## Summary
- Document the new `eligibleForBorescopeAnalysis` boolean and optional `serviceUpgradeUrl` fields on the GetAircraft response, matching the API change in savvyaviation/savvyanalysis#7103.
- Add response examples for the eligible and ineligible cases.

Linear: [SAV-3176](https://linear.app/savvyaviationinc/issue/SAV-3176/borescope-api-analysis-eligibility)
Related API PR: savvyaviation/savvyanalysis#7103

## Test plan
- [ ] Render the OpenAPI spec and confirm the new fields + examples display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)